### PR TITLE
Add events to contract suite

### DIFF
--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -11,8 +11,8 @@ pub contract CapabilityFilter {
 
     /* Events */
     //
-    pub event TypeAdded(id: UInt64, filterType: Type, newType: String) // TODO: Decide on Type or identifier String
-    pub event TypeRemoved(id: UInt64, filterType: Type, removedType: String) // TODO: Decide on Type or identifier String
+    pub event TypeAdded(id: UInt64, filterType: Type, newType: String)
+    pub event TypeRemoved(id: UInt64, filterType: Type, removedType: String)
 
     pub resource interface Filter {
         pub fun allowed(cap: Capability): Bool

--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -9,6 +9,11 @@ pub contract CapabilityFilter {
     pub let PublicPath: PublicPath
     pub let PrivatePath: PrivatePath
 
+    /* Events */
+    //
+    pub event TypeAdded(id: UInt64, filterType: Type, newType: Type) // TODO: Decide on Type or identifier String
+    pub event TypeRemoved(id: UInt64, filterType: Type, removedType: Type) // TODO: Decide on Type or identifier String
+
     pub resource interface Filter {
         pub fun allowed(cap: Capability): Bool
         pub fun getDetails(): AnyStruct
@@ -24,10 +29,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.deniedTypes.insert(key: type, true)
+            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type)
         }
 
         pub fun removeType(_ type: Type) {
             self.deniedTypes.remove(key: type)
+            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type)
         }
 
         pub fun allowed(cap: Capability): Bool {
@@ -60,10 +67,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.allowedTypes.insert(key: type, true)
+            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type)
         }
 
         pub fun removeType(_ type: Type) {
             self.allowedTypes.remove(key: type)
+            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type)
         }
 
         pub fun allowed(cap: Capability): Bool {

--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -11,8 +11,7 @@ pub contract CapabilityFilter {
 
     /* Events */
     //
-    pub event TypeAdded(id: UInt64, filterType: Type, newType: String)
-    pub event TypeRemoved(id: UInt64, filterType: Type, removedType: String)
+    pub event FilterUpdated(id: UInt64, filterType: String, type: String, active: Bool)
 
     pub resource interface Filter {
         pub fun allowed(cap: Capability): Bool
@@ -29,12 +28,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.deniedTypes.insert(key: type, true)
-            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type.identifier)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: true)
         }
 
         pub fun removeType(_ type: Type) {
             self.deniedTypes.remove(key: type)
-            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type.identifier)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: false)
         }
 
         pub fun allowed(cap: Capability): Bool {
@@ -67,12 +66,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.allowedTypes.insert(key: type, true)
-            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type.identifier)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: true)
         }
 
         pub fun removeType(_ type: Type) {
             self.allowedTypes.remove(key: type)
-            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type.identifier)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: false)
         }
 
         pub fun allowed(cap: Capability): Bool {

--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -11,7 +11,7 @@ pub contract CapabilityFilter {
 
     /* Events */
     //
-    pub event FilterUpdated(id: UInt64, filterType: String, type: String, active: Bool)
+    pub event FilterUpdated(id: UInt64, filterType: Type, type: Type, active: Bool)
 
     pub resource interface Filter {
         pub fun allowed(cap: Capability): Bool
@@ -28,12 +28,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.deniedTypes.insert(key: type, true)
-            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: true)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: true)
         }
 
         pub fun removeType(_ type: Type) {
             self.deniedTypes.remove(key: type)
-            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: false)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: false)
         }
 
         pub fun allowed(cap: Capability): Bool {
@@ -66,12 +66,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.allowedTypes.insert(key: type, true)
-            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: true)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: true)
         }
 
         pub fun removeType(_ type: Type) {
             self.allowedTypes.remove(key: type)
-            emit FilterUpdated(id: self.uuid, filterType: self.getType().identifier, type: type.identifier, active: false)
+            emit FilterUpdated(id: self.uuid, filterType: self.getType(), type: type, active: false)
         }
 
         pub fun allowed(cap: Capability): Bool {

--- a/contracts/CapabilityFilter.cdc
+++ b/contracts/CapabilityFilter.cdc
@@ -11,8 +11,8 @@ pub contract CapabilityFilter {
 
     /* Events */
     //
-    pub event TypeAdded(id: UInt64, filterType: Type, newType: Type) // TODO: Decide on Type or identifier String
-    pub event TypeRemoved(id: UInt64, filterType: Type, removedType: Type) // TODO: Decide on Type or identifier String
+    pub event TypeAdded(id: UInt64, filterType: Type, newType: String) // TODO: Decide on Type or identifier String
+    pub event TypeRemoved(id: UInt64, filterType: Type, removedType: String) // TODO: Decide on Type or identifier String
 
     pub resource interface Filter {
         pub fun allowed(cap: Capability): Bool
@@ -29,12 +29,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.deniedTypes.insert(key: type, true)
-            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type)
+            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type.identifier)
         }
 
         pub fun removeType(_ type: Type) {
             self.deniedTypes.remove(key: type)
-            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type)
+            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type.identifier)
         }
 
         pub fun allowed(cap: Capability): Bool {
@@ -67,12 +67,12 @@ pub contract CapabilityFilter {
 
         pub fun addType(_ type: Type) {
             self.allowedTypes.insert(key: type, true)
-            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type)
+            emit TypeAdded(id: self.uuid, filterType: self.getType(), newType: type.identifier)
         }
 
         pub fun removeType(_ type: Type) {
             self.allowedTypes.remove(key: type)
-            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type)
+            emit TypeRemoved(id: self.uuid, filterType: self.getType(), removedType: type.identifier)
         }
 
         pub fun allowed(cap: Capability): Bool {

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -18,8 +18,8 @@ pub contract CapabilityProxy {
     /* Events */
     //
     pub event ProxyCreated(id: UInt64)
-    pub event CapabilityAdded(id: UInt64, type: String, isPublic: Bool) // TODO: Decide on Type or identifier String
-    pub event CapabilityRemoved(id: UInt64, type: String) // TODO: Decide on Type or identifier String
+    pub event CapabilityAdded(id: UInt64, type: String, isPublic: Bool)
+    pub event CapabilityRemoved(id: UInt64, type: String)
 
     pub resource interface GetterPrivate {
         pub fun getPrivateCapability(_ type: Type): Capability? {

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -15,8 +15,9 @@ pub contract CapabilityProxy {
     pub let PrivatePath: PrivatePath
     pub let PublicPath: PublicPath
     
+    /* Events */
+    //
     pub event ProxyCreated(id: UInt64)
-    
     pub event CapabilityAdded(id: UInt64, type: Type, isPublic: Bool) // TODO: Decide on Type or identifier String
     pub event CapabilityRemoved(id: UInt64, type: Type) // TODO: Decide on Type or identifier String
 

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -18,7 +18,7 @@ pub contract CapabilityProxy {
     /* Events */
     //
     pub event ProxyCreated(id: UInt64)
-    pub event ProxyUpdated(id: UInt64, capabilityType: String, isPublic: Bool, active: Bool)
+    pub event ProxyUpdated(id: UInt64, capabilityType: Type, isPublic: Bool, active: Bool)
 
     pub resource interface GetterPrivate {
         pub fun getPrivateCapability(_ type: Type): Capability? {
@@ -90,14 +90,14 @@ pub contract CapabilityProxy {
             } else {
                 self.privateCapabilities.insert(key: cap.getType(), cap)
             }
-            emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType().identifier, isPublic: isPublic, active: true)
+            emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType(), isPublic: isPublic, active: true)
         }
 
         pub fun removeCapability(cap: Capability) {
             let removedPublic = self.publicCapabilities.remove(key: cap.getType())
             self.privateCapabilities.remove(key: cap.getType())
 
-            emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType().identifier, isPublic: removedPublic != nil, active: false)
+            emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType(), isPublic: removedPublic != nil, active: false)
         }
 
         init() {
@@ -119,3 +119,4 @@ pub contract CapabilityProxy {
         self.PublicPath = PublicPath(identifier: identifier)!
     }
 }
+ 

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -94,10 +94,13 @@ pub contract CapabilityProxy {
         }
 
         pub fun removeCapability(cap: Capability) {
-            let removedPublic = self.publicCapabilities.remove(key: cap.getType())
-            self.privateCapabilities.remove(key: cap.getType())
-
-            emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType(), isPublic: removedPublic != nil, active: false)
+            if let removedPublic = self.publicCapabilities.remove(key: cap.getType()) {
+                emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType(), isPublic: true, active: false)
+            }
+            
+            if let removedPrivate = self.privateCapabilities.remove(key: cap.getType()) {
+                emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType(), isPublic: false, active: false)
+            }
         }
 
         init() {

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -18,8 +18,8 @@ pub contract CapabilityProxy {
     /* Events */
     //
     pub event ProxyCreated(id: UInt64)
-    pub event CapabilityAdded(id: UInt64, type: Type, isPublic: Bool) // TODO: Decide on Type or identifier String
-    pub event CapabilityRemoved(id: UInt64, type: Type) // TODO: Decide on Type or identifier String
+    pub event CapabilityAdded(id: UInt64, type: String, isPublic: Bool) // TODO: Decide on Type or identifier String
+    pub event CapabilityRemoved(id: UInt64, type: String) // TODO: Decide on Type or identifier String
 
     pub resource interface GetterPrivate {
         pub fun getPrivateCapability(_ type: Type): Capability? {
@@ -91,14 +91,14 @@ pub contract CapabilityProxy {
             } else {
                 self.privateCapabilities.insert(key: cap.getType(), cap)
             }
-            emit CapabilityAdded(id: self.uuid, type: cap.getType(), isPublic: isPublic)
+            emit CapabilityAdded(id: self.uuid, type: cap.getType().identifier, isPublic: isPublic)
         }
 
         pub fun removeCapability(cap: Capability) {
             self.publicCapabilities.remove(key: cap.getType())
             self.privateCapabilities.remove(key: cap.getType())
 
-            emit CapabilityRemoved(id: self.uuid, type: cap.getType())
+            emit CapabilityRemoved(id: self.uuid, type: cap.getType().identifier)
         }
 
         init() {

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -17,8 +17,8 @@ pub contract CapabilityProxy {
     
     pub event ProxyCreated(id: UInt64)
     
-    pub event CapabilityAdded(address: Address, type: Type, isPublic: Bool)
-    pub event CapabilityRemoved(address: Address, type: Type)
+    pub event CapabilityAdded(id: UInt64, type: Type, isPublic: Bool) // TODO: Decide on Type or identifier String
+    pub event CapabilityRemoved(id: UInt64, type: Type) // TODO: Decide on Type or identifier String
 
     pub resource interface GetterPrivate {
         pub fun getPrivateCapability(_ type: Type): Capability? {
@@ -90,11 +90,14 @@ pub contract CapabilityProxy {
             } else {
                 self.privateCapabilities.insert(key: cap.getType(), cap)
             }
+            emit CapabilityAdded(id: self.uuid, type: cap.getType(), isPublic: isPublic)
         }
 
         pub fun removeCapability(cap: Capability) {
             self.publicCapabilities.remove(key: cap.getType())
             self.privateCapabilities.remove(key: cap.getType())
+
+            emit CapabilityRemoved(id: self.uuid, type: cap.getType())
         }
 
         init() {
@@ -104,7 +107,9 @@ pub contract CapabilityProxy {
     }
 
     pub fun createProxy(): @Proxy {
-        return <- create Proxy()
+        let proxy <- create Proxy()
+        emit ProxyCreated(id: proxy.uuid)
+        return <- proxy
     }
     
     init() {

--- a/contracts/CapabilityProxy.cdc
+++ b/contracts/CapabilityProxy.cdc
@@ -18,8 +18,7 @@ pub contract CapabilityProxy {
     /* Events */
     //
     pub event ProxyCreated(id: UInt64)
-    pub event CapabilityAdded(id: UInt64, type: String, isPublic: Bool)
-    pub event CapabilityRemoved(id: UInt64, type: String)
+    pub event ProxyUpdated(id: UInt64, capabilityType: String, isPublic: Bool, active: Bool)
 
     pub resource interface GetterPrivate {
         pub fun getPrivateCapability(_ type: Type): Capability? {
@@ -91,14 +90,14 @@ pub contract CapabilityProxy {
             } else {
                 self.privateCapabilities.insert(key: cap.getType(), cap)
             }
-            emit CapabilityAdded(id: self.uuid, type: cap.getType().identifier, isPublic: isPublic)
+            emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType().identifier, isPublic: isPublic, active: true)
         }
 
         pub fun removeCapability(cap: Capability) {
-            self.publicCapabilities.remove(key: cap.getType())
+            let removedPublic = self.publicCapabilities.remove(key: cap.getType())
             self.privateCapabilities.remove(key: cap.getType())
 
-            emit CapabilityRemoved(id: self.uuid, type: cap.getType().identifier)
+            emit ProxyUpdated(id: self.uuid, capabilityType: cap.getType().identifier, isPublic: removedPublic != nil, active: false)
         }
 
         init() {
@@ -120,4 +119,3 @@ pub contract CapabilityProxy {
         self.PublicPath = PublicPath(identifier: identifier)!
     }
 }
- 

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -38,7 +38,7 @@ pub contract HybridCustody {
     pub event CreatedManager(id: UInt64)
     pub event CreatedChildAccount(id: UInt64, child: Address)
     pub event AccountUpdated(id: UInt64?, child: Address, parent: Address, proxy: Bool, active: Bool)
-    pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, filterType: String, child: Address, pendingParent: Address)
+    pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, filterType: Type, child: Address, pendingParent: Address)
     pub event ChildAccountRedeemed(id: UInt64, child: Address, parent: Address)
     pub event RemovedParent(id: UInt64, child: Address, parent: Address)
     pub event OwnershipGranted(id: UInt64, child: Address, owner: Address)
@@ -503,7 +503,7 @@ pub contract HybridCustody {
                 capProxyID: proxy.borrow()!.uuid,
                 factoryID: factory.borrow()!.uuid,
                 filterID: filter.borrow()!.uuid,
-                filterType: filter.getType().identifier,
+                filterType: filter.getType(),
                 child: self.acct.address,
                 pendingParent: parentAddress
             )
@@ -512,7 +512,7 @@ pub contract HybridCustody {
             let s = StoragePath(identifier: identifier)!
             let p = PrivatePath(identifier: identifier)!
 
-            acct.save(<-proxyAcct, to: s)
+            acct.save(<-proxyAcct, to: s) // TODO: Handle case where ProxyAccount is already saved, e.g. previously published for parentAddress
             acct.link<&ProxyAccount{AccountPrivate, AccountPublic}>(p, target: s)
             
             let proxyCap = acct.getCapability<&ProxyAccount{AccountPrivate, AccountPublic}>(p)

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -485,7 +485,7 @@ pub contract HybridCustody {
             if acct.borrow<&CapabilityProxy.Proxy>(from: capProxyStorage) == nil {
                 let proxy <- CapabilityProxy.createProxy()
                 acct.save(<-proxy, to: capProxyStorage)
-            } 
+            }
 
             let capProxyPublic = PublicPath(identifier: capProxyIdentifier)!
             let capProxyPrivate = PrivatePath(identifier: capProxyIdentifier)!

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -33,7 +33,19 @@ pub contract HybridCustody {
     pub let LinkedAccountPrivatePath: PrivatePath
     pub let BorrowableAccountPrivatePath: PrivatePath
 
-    // TODO: Events!
+    /* Events */
+    //
+    pub event CreatedManager(id: UInt64)
+    pub event CreatedChildAccount(id: UInt64, child: Address)
+    pub event AddedProxyAccount(id: UInt64, child: Address, parent: Address)
+    pub event AddedOwnedAccount(id: UInt64, child: Address, parent: Address)
+    pub event RemovedProxyAccount(id: UInt64?, child: Address, parent: Address)
+    pub event RemovedOwnedAccount(id: UInt64?, child: Address, parent: Address)
+    pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, child: Address, pendingParent: Address)
+    pub event ChildAccountRedeemed(id: UInt64, child: Address, parent: Address)
+    pub event RemovedParent(id: UInt64, child: Address, parent: Address)
+    pub event OwnershipGranted(id: UInt64, child: Address, parent: Address)
+    pub event SealedAccount(id: UInt64, address: Address, parents: [Address])
 
     // An interface which gets shared to a Manager when it is given full ownership of an account.
     pub resource interface Account {
@@ -196,7 +208,7 @@ pub contract HybridCustody {
 
             self.accounts[cap.address] = cap
             
-            // TODO: emit account registered event
+            emit AddedProxyAccount(id: acct.uuid, child: cap.address, parent: self.owner!.address)
 
             acct.redeemedCallback(self.owner!.address)
             acct.setManagerCapabilityFilter(self.filter)
@@ -210,8 +222,11 @@ pub contract HybridCustody {
         }
 
         pub fun removeChild(addr: Address) {
-            let cap = self.accounts.remove(key: addr)
-            // TODO: emit event if cap is not nil
+            if let cap = self.accounts.remove(key: addr) {
+                // TODO: Add access(contract) methods that flow down to ChildAccount s.t. parent is removed if exists in ChildAccount.parents
+                let id: UInt64? = cap.borrow()?.uuid ?? nil
+                emit RemovedProxyAccount(id: id, child: cap.address, parent: self.owner!.address)
+            }
         }
 
         pub fun addOwnedAccount(_ cap: Capability<&{Account, ChildAccountPublic, ChildAccountPrivate}>) {
@@ -221,8 +236,9 @@ pub contract HybridCustody {
 
             let acct = cap.borrow()
                 ?? panic("cannot add invalid account")
-
             self.ownedAccounts[cap.address] = cap
+
+            emit AddedOwnedAccount(id: acct.uuid, child: cap.address, parent: self.owner!.address)
         }
 
         pub fun getAddresses(): [Address] {
@@ -260,8 +276,8 @@ pub contract HybridCustody {
                 if acct.check() {
                     acct.borrow()!.seal() // TODO: this should probably not fail, otherwise the owner cannot get rid of a broken link
                 }
-
-                // TODO: emit event
+                let id: UInt64? = acct.borrow()?.uuid ?? nil
+                emit RemovedOwnedAccount(id: id, child: acct.address, parent: self.owner!.address)
             }
 
             // Don't emit an event if nothing was removed
@@ -440,6 +456,8 @@ pub contract HybridCustody {
             }
 
             self.parents[addr] = true
+
+            emit ChildAccountRedeemed(id: self.uuid, child: self.acct.address, parent: addr)
         }
 
         /*
@@ -471,7 +489,7 @@ pub contract HybridCustody {
             if acct.borrow<&CapabilityProxy.Proxy>(from: capProxyStorage) == nil {
                 let proxy <- CapabilityProxy.createProxy()
                 acct.save(<-proxy, to: capProxyStorage)
-            }
+            } 
 
             let capProxyPublic = PublicPath(identifier: capProxyIdentifier)!
             let capProxyPrivate = PrivatePath(identifier: capProxyIdentifier)!
@@ -483,8 +501,9 @@ pub contract HybridCustody {
 
             let borrowableCap = self.borrowAccount().getCapability<&{BorrowableAccount, ChildAccountPublic}>(HybridCustody.ChildPrivatePath)
             let proxyAcct <- create ProxyAccount(borrowableCap, factory, filter, proxy, parentAddress)
-            let identifier = HybridCustody.getProxyAccountIdentifier(parentAddress)
+            emit ProxyAccountPublished(childAcctID: self.uuid, proxyAcctID: proxyAcct.uuid, capProxyID: proxy.borrow()!.uuid, factoryID: factory.borrow()!.uuid, filterID: filter.borrow()!.uuid, child: self.acct.address, pendingParent: parentAddress)
 
+            let identifier = HybridCustody.getProxyAccountIdentifier(parentAddress)
             let s = StoragePath(identifier: identifier)!
             let p = PrivatePath(identifier: identifier)!
 
@@ -545,8 +564,8 @@ pub contract HybridCustody {
             destroy <- acct.load<@AnyResource>(from: StoragePath(identifier: capProxyIdentifier)!)
 
             self.parents.remove(key: parent)
+            emit RemovedParent(id: self.uuid, child: self.acct.address, parent: parent)
 
-            // TODO: emit event
             return true
         }
 
@@ -574,7 +593,7 @@ pub contract HybridCustody {
             self.acctOwner = to
             self.relinquishedOwnership = false
 
-            // TODO: Emit event!
+            emit OwnershipGranted(id: self.uuid, child: self.acct.address, owner: to)
         }
 
         // seal
@@ -621,7 +640,9 @@ pub contract HybridCustody {
             for  p in pathsToUnlink {
                 newAcct.unlink(p)
             }
-            
+
+            emit SealedAccount(id: self.uuid, address: self.acct.address, parents: self.parents.keys)
+
             self.relinquishedOwnership = true
         }
 
@@ -689,11 +710,15 @@ pub contract HybridCustody {
             acct.check(): "invalid auth account capability"
         }
 
-        return <- create ChildAccount(acct)
+        let childAcct <- create ChildAccount(acct)
+        emit CreatedChildAccount(id: childAcct.id, child: acct.borrow()!.address)
+        return <- childAcct
     }
 
     pub fun createManager(filter: Capability<&{CapabilityFilter.Filter}>?): @Manager {
-        return <- create Manager(filter: filter)
+        let manager <- create Manager()
+        emit CreatedManager(id: manager.uuid)
+        return <- manager
     }
 
     init() {

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -38,11 +38,11 @@ pub contract HybridCustody {
     pub event CreatedManager(id: UInt64)
     pub event CreatedChildAccount(id: UInt64, child: Address)
     pub event AccountUpdated(id: UInt64?, child: Address, parent: Address, proxy: Bool, active: Bool)
-    pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, filterType: Type, child: Address, pendingParent: Address) // TODO: Decide on Type or identifier String
+    pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, filterType: String, child: Address, pendingParent: Address)
     pub event ChildAccountRedeemed(id: UInt64, child: Address, parent: Address)
     pub event RemovedParent(id: UInt64, child: Address, parent: Address)
     pub event OwnershipGranted(id: UInt64, child: Address, owner: Address)
-    pub event SealedAccount(id: UInt64, address: Address, parents: [Address])
+    pub event AccountSealed(id: UInt64, address: Address, parents: [Address])
 
     // An interface which gets shared to a Manager when it is given full ownership of an account.
     pub resource interface Account {
@@ -503,7 +503,7 @@ pub contract HybridCustody {
                 capProxyID: proxy.borrow()!.uuid,
                 factoryID: factory.borrow()!.uuid,
                 filterID: filter.borrow()!.uuid,
-                filterType: filter.getType(),
+                filterType: filter.getType().identifier,
                 child: self.acct.address,
                 pendingParent: parentAddress
             )
@@ -646,7 +646,7 @@ pub contract HybridCustody {
                 newAcct.unlink(p)
             }
 
-            emit SealedAccount(id: self.uuid, address: self.acct.address, parents: self.parents.keys)
+            emit AccountSealed(id: self.uuid, address: self.acct.address, parents: self.parents.keys)
 
             self.relinquishedOwnership = true
         }

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -44,7 +44,7 @@ pub contract HybridCustody {
     pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, filterType: Type, child: Address, pendingParent: Address) // TODO: Decide on Type or identifier String
     pub event ChildAccountRedeemed(id: UInt64, child: Address, parent: Address)
     pub event RemovedParent(id: UInt64, child: Address, parent: Address)
-    pub event OwnershipGranted(id: UInt64, child: Address, parent: Address)
+    pub event OwnershipGranted(id: UInt64, child: Address, owner: Address)
     pub event SealedAccount(id: UInt64, address: Address, parents: [Address])
 
     // An interface which gets shared to a Manager when it is given full ownership of an account.
@@ -711,12 +711,12 @@ pub contract HybridCustody {
         }
 
         let childAcct <- create ChildAccount(acct)
-        emit CreatedChildAccount(id: childAcct.id, child: acct.borrow()!.address)
+        emit CreatedChildAccount(id: childAcct.uuid, child: acct.borrow()!.address)
         return <- childAcct
     }
 
     pub fun createManager(filter: Capability<&{CapabilityFilter.Filter}>?): @Manager {
-        let manager <- create Manager()
+        let manager <- create Manager(filter: filter)
         emit CreatedManager(id: manager.uuid)
         return <- manager
     }

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -41,7 +41,7 @@ pub contract HybridCustody {
     pub event AddedOwnedAccount(id: UInt64, child: Address, parent: Address)
     pub event RemovedProxyAccount(id: UInt64?, child: Address, parent: Address)
     pub event RemovedOwnedAccount(id: UInt64?, child: Address, parent: Address)
-    pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, child: Address, pendingParent: Address)
+    pub event ProxyAccountPublished(childAcctID: UInt64, proxyAcctID: UInt64, capProxyID: UInt64, factoryID: UInt64, filterID: UInt64, filterType: Type, child: Address, pendingParent: Address) // TODO: Decide on Type or identifier String
     pub event ChildAccountRedeemed(id: UInt64, child: Address, parent: Address)
     pub event RemovedParent(id: UInt64, child: Address, parent: Address)
     pub event OwnershipGranted(id: UInt64, child: Address, parent: Address)
@@ -501,7 +501,7 @@ pub contract HybridCustody {
 
             let borrowableCap = self.borrowAccount().getCapability<&{BorrowableAccount, ChildAccountPublic}>(HybridCustody.ChildPrivatePath)
             let proxyAcct <- create ProxyAccount(borrowableCap, factory, filter, proxy, parentAddress)
-            emit ProxyAccountPublished(childAcctID: self.uuid, proxyAcctID: proxyAcct.uuid, capProxyID: proxy.borrow()!.uuid, factoryID: factory.borrow()!.uuid, filterID: filter.borrow()!.uuid, child: self.acct.address, pendingParent: parentAddress)
+            emit ProxyAccountPublished(childAcctID: self.uuid, proxyAcctID: proxyAcct.uuid, capProxyID: proxy.borrow()!.uuid, factoryID: factory.borrow()!.uuid, filterID: filter.borrow()!.uuid, filterType: filter.getType(), child: self.acct.address, pendingParent: parentAddress)
 
             let identifier = HybridCustody.getProxyAccountIdentifier(parentAddress)
             let s = StoragePath(identifier: identifier)!

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -93,7 +93,12 @@ pub contract HybridCustody {
             parentAddress: Address,
             factory: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>,
             filter: Capability<&{CapabilityFilter.Filter}>
-        )
+        ) {
+            pre {
+                factory.check(): "Invalid CapabilityFactory.Getter Capability provided"
+                filter.check(): "Invalid CapabilityFilter Capability provided"
+            }
+        }
 
         // giveOwnership
         // Passes ownership of this child account to the given address. Once executed, all active keys on 
@@ -111,12 +116,20 @@ pub contract HybridCustody {
         // setCapabilityFactoryForParent
         // Override the existing CapabilityFactory Capability for a given parent. This will allow the owner of the account
         // to start managing their own factory of capabilities to be able to retrieve
-        pub fun setCapabilityFactoryForParent(parent: Address, cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>)
+        pub fun setCapabilityFactoryForParent(parent: Address, cap: Capability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>) {
+            pre {
+                cap.check(): "Invalid CapabilityFactory.Getter Capability provided"
+            }
+        }
 
         // setCapabilityFilterForParent
         // Override the existing CapabilityFilter Capability for a given parent. This will allow the owner of the account
         // to start managing their own filter for retrieving Capabilities on Private Paths
-        pub fun setCapabilityFilterForParent(parent: Address, cap: Capability<&{CapabilityFilter.Filter}>)
+        pub fun setCapabilityFilterForParent(parent: Address, cap: Capability<&{CapabilityFilter.Filter}>) {
+            pre {
+                cap.check(): "Invalid CapabilityFilter Capability provided"
+            }
+        }
 
         // addCapabilityToProxy
         // Adds a capability to a parent's managed @ProxyAccount resource. The Capability can be made public,

--- a/contracts/HybridCustody.cdc
+++ b/contracts/HybridCustody.cdc
@@ -497,7 +497,16 @@ pub contract HybridCustody {
 
             let borrowableCap = self.borrowAccount().getCapability<&{BorrowableAccount, ChildAccountPublic}>(HybridCustody.ChildPrivatePath)
             let proxyAcct <- create ProxyAccount(borrowableCap, factory, filter, proxy, parentAddress)
-            emit ProxyAccountPublished(childAcctID: self.uuid, proxyAcctID: proxyAcct.uuid, capProxyID: proxy.borrow()!.uuid, factoryID: factory.borrow()!.uuid, filterID: filter.borrow()!.uuid, filterType: filter.getType(), child: self.acct.address, pendingParent: parentAddress)
+            emit ProxyAccountPublished(
+                childAcctID: self.uuid,
+                proxyAcctID: proxyAcct.uuid,
+                capProxyID: proxy.borrow()!.uuid,
+                factoryID: factory.borrow()!.uuid,
+                filterID: filter.borrow()!.uuid,
+                filterType: filter.getType(),
+                child: self.acct.address,
+                pendingParent: parentAddress
+            )
 
             let identifier = HybridCustody.getProxyAccountIdentifier(parentAddress)
             let s = StoragePath(identifier: identifier)!


### PR DESCRIPTION
Closes: #15

## Description

Adding events to HybridCustody, CapabilityProxy, and CapabilityFilter contracts. The initial form of this PR should not be taken as prescriptive or final, but as a concrete starting point to drive discussions around the topic and quickly iterate on if needed.

At a high level, we want a user to know:
1. When they have an account available to claim
2. When they have successfully claimed said account access
3. Identifying info about the resources involved in their access on an account
4. When their account has been removed, either by their direct action or by another party with the ability to do so
5. When a Capability has been added/removed to/from a relevant CapabilityProxy
6. When a new Type has been added/removed to/from a relevant CapabilityFilter
7. When they have been given ownership over an account
8. When an account has been sealed

## Included events

With those questions in mind, here's an overview of the events included in the PR as submitted:

### HybridCustody
```js
pub event CreatedManager(id: UInt64)
pub event CreatedChildAccount(id: UInt64, child: Address)
pub event AddedProxyAccount(id: UInt64, child: Address, parent: Address)
pub event AddedOwnedAccount(id: UInt64, child: Address, parent: Address)
pub event RemovedProxyAccount(id: UInt64?, child: Address, parent: Address)
pub event RemovedOwnedAccount(id: UInt64?, child: Address, parent: Address)
pub event ProxyAccountPublished(
    childAcctID: UInt64,
    proxyAcctID: UInt64,
    capProxyID: UInt64,
    factoryID: UInt64,
    filterID: UInt64,
    filterType: Type,
    child: Address,
    pendingParent: Address
)
pub event ChildAccountRedeemed(id: UInt64, child: Address, parent: Address)
pub event RemovedParent(id: UInt64, child: Address, parent: Address)
pub event OwnershipGranted(id: UInt64, child: Address, parent: Address)
pub event SealedAccount(id: UInt64, address: Address, parents: [Address])
```

### CapabilityProxy
```js
pub event ProxyCreated(id: UInt64)
pub event CapabilityAdded(id: UInt64, type: Type, isPublic: Bool)
pub event CapabilityRemoved(id: UInt64, type: Type)
```

### CapabilityFilter
```js
pub event TypeAdded(id: UInt64, filterType: Type, newType: Type)
pub event TypeRemoved(id: UInt64, filterType: Type, removedType: Type)
```

## Open questions:
- Is it more useful to emit `Type.identifier` or Type in events?
- How much data (if any) do we want to emit about accessible Types in the `ProxyAccountPublished` event? This might be informed by conversations around #18 and #19
