### PR TITLE
Add FungibleToken balance queries

### DIFF
--- a/scripts/hybrid-custody/get_all_flow_balances.cdc
+++ b/scripts/hybrid-custody/get_all_flow_balances.cdc
@@ -1,0 +1,31 @@
+import "FungibleToken"
+import "HybridCustody"
+
+/// Queries for $FLOW balance of a given Address and all its associated accounts
+///
+pub fun main(address: Address): {Address: UFix64} {
+
+    // Get the balance for the given address
+    let balances: {Address: UFix64} = { address: getAccount(address).balance }
+    // Tracking Addresses we've come across to prevent overwriting balances more efficiently than checking return mapping
+    let seen: [Address] = [address]
+    
+    /* Iterate over any associated accounts */ 
+    //
+    if let managerRef = getAuthAccount(address).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+        
+        for childAccount in managerRef.getChildAddresses() {
+            balances.insert(key: childAccount, getAccount(childAccount).balance)
+            seen.append(childAccount)
+        }
+
+        for ownedAccount in managerRef.getOwnedAddresses() {
+            if seen.contains(ownedAccount) == false {
+                balances.insert(key: ownedAccount, getAccount(ownedAccount).balance)
+                seen.append(ownedAccount)
+            }
+        }
+    }
+
+    return balances 
+}

--- a/scripts/hybrid-custody/get_all_vault_bal_from_storage.cdc
+++ b/scripts/hybrid-custody/get_all_vault_bal_from_storage.cdc
@@ -4,7 +4,7 @@ import "HybridCustody"
 
 /// Returns a mapping of balances indexed on the Type of resource containing the balance
 ///
-pub fun getAllVaultInfoInAddressStorage(_ address: Address): {Type: UFix64} {
+pub fun getAllBalancesInStorage(_ address: Address): {Type: UFix64} {
     // Get the account
     let account: AuthAccount = getAuthAccount(address)
     // Init for return value
@@ -37,7 +37,7 @@ pub fun getAllVaultInfoInAddressStorage(_ address: Address): {Type: UFix64} {
 pub fun main(address: Address): {Address: {Type: UFix64}} {
 
     // Get the balance for the given address
-    let balances: {Address: {Type: UFix64}} = { address: getAllVaultInfoInAddressStorage(address) }
+    let balances: {Address: {Type: UFix64}} = { address: getAllBalancesInStorage(address) }
     // Tracking Addresses we've come across to prevent overwriting balances (more efficient than checking dict entries (?))
     let seen: [Address] = [address]
     
@@ -47,13 +47,13 @@ pub fun main(address: Address): {Address: {Type: UFix64}} {
         .borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
         
         for childAccount in managerRef.getChildAddresses() {
-            balances.insert(key: childAccount, getAllVaultInfoInAddressStorage(address))
+            balances.insert(key: childAccount, getAllBalancesInStorage(address))
             seen.append(childAccount)
         }
 
         for ownedAccount in managerRef.getOwnedAddresses() {
             if seen.contains(ownedAccount) == false {
-                balances.insert(key: ownedAccount, getAllVaultInfoInAddressStorage(address))
+                balances.insert(key: ownedAccount, getAllBalancesInStorage(address))
                 seen.append(ownedAccount)
             }
         }

--- a/scripts/hybrid-custody/get_all_vault_bal_from_storage.cdc
+++ b/scripts/hybrid-custody/get_all_vault_bal_from_storage.cdc
@@ -2,7 +2,8 @@ import "FungibleToken"
 import "MetadataViews"
 import "HybridCustody"
 
-/// Returns a dictionary of VaultInfo indexed on the Type of Vault
+/// Returns a mapping of balances indexed on the Type of resource containing the balance
+///
 pub fun getAllVaultInfoInAddressStorage(_ address: Address): {Type: UFix64} {
     // Get the account
     let account: AuthAccount = getAuthAccount(address)
@@ -15,9 +16,9 @@ pub fun getAllVaultInfoInAddressStorage(_ address: Address): {Type: UFix64} {
     // Iterate over all stored items & get the path if the type is what we're looking for
     account.forEachStored(fun (path: StoragePath, type: Type): Bool {
         if type.isInstance(balanceType) || type.isSubtype(of: balanceType) {
-            // Get a reference to the vault & its balance
+            // Get a reference to the resource & its balance
             let vaultRef = account.borrow<&{FungibleToken.Balance}>(from: path)!
-            // Insert a new info struct if it's the first time we've seen the vault type
+            // Insert a new values if it's the first time we've seen the type
             if !seen.contains(type) {
                 balances.insert(key: type, vaultRef.balance)
             } else {

--- a/scripts/hybrid-custody/get_all_vault_bal_from_storage.cdc
+++ b/scripts/hybrid-custody/get_all_vault_bal_from_storage.cdc
@@ -1,0 +1,63 @@
+import "FungibleToken"
+import "MetadataViews"
+import "HybridCustody"
+
+/// Returns a dictionary of VaultInfo indexed on the Type of Vault
+pub fun getAllVaultInfoInAddressStorage(_ address: Address): {Type: UFix64} {
+    // Get the account
+    let account: AuthAccount = getAuthAccount(address)
+    // Init for return value
+    let balances: {Type: UFix64} = {}
+    // Track seen Types in array
+    let seen: [Type] = []
+    // Assign the type we'll need
+    let balanceType: Type = Type<@{FungibleToken.Balance}>()
+    // Iterate over all stored items & get the path if the type is what we're looking for
+    account.forEachStored(fun (path: StoragePath, type: Type): Bool {
+        if type.isInstance(balanceType) || type.isSubtype(of: balanceType) {
+            // Get a reference to the vault & its balance
+            let vaultRef = account.borrow<&{FungibleToken.Balance}>(from: path)!
+            // Insert a new info struct if it's the first time we've seen the vault type
+            if !seen.contains(type) {
+                balances.insert(key: type, vaultRef.balance)
+            } else {
+                // Otherwise just update the balance of the vault (unlikely we'll see the same type twice in
+                // the same account, but we want to cover the case)
+                balances[type] = balances[type]! + vaultRef.balance
+            }
+        }
+        return true
+    })
+    return balances
+}
+
+/// Queries for FT.Vault balance of all FT.Vaults in the specified account and all of its associated accounts
+///
+pub fun main(address: Address): {Address: {Type: UFix64}} {
+
+    // Get the balance for the given address
+    let balances: {Address: {Type: UFix64}} = { address: getAllVaultInfoInAddressStorage(address) }
+    // Tracking Addresses we've come across to prevent overwriting balances (more efficient than checking dict entries (?))
+    let seen: [Address] = [address]
+    
+    /* Iterate over any associated accounts */ 
+    //
+    if let managerRef = getAuthAccount(address)
+        .borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+        
+        for childAccount in managerRef.getChildAddresses() {
+            balances.insert(key: childAccount, getAllVaultInfoInAddressStorage(address))
+            seen.append(childAccount)
+        }
+
+        for ownedAccount in managerRef.getOwnedAddresses() {
+            if seen.contains(ownedAccount) == false {
+                balances.insert(key: ownedAccount, getAllVaultInfoInAddressStorage(address))
+                seen.append(ownedAccount)
+            }
+        }
+    }
+
+    return balances 
+}
+ 

--- a/scripts/hybrid-custody/get_spec_balance_from_public.cdc
+++ b/scripts/hybrid-custody/get_spec_balance_from_public.cdc
@@ -1,7 +1,7 @@
 import "FungibleToken"
 import "HybridCustody"
 
-/// Returns a dictionary of VaultInfo indexed on the Type of Vault
+/// Returns the balance of the object (presumably a FungibleToken Vault) at the given path in the specified account
 ///
 pub fun getVaultBalance(_ address: Address, _ balancePath: PublicPath): UFix64 {
     return getAccount(address).getCapability<&{FungibleToken.Balance}>(balancePath).borrow()?.balance ?? 0.0

--- a/scripts/hybrid-custody/get_spec_balance_from_public.cdc
+++ b/scripts/hybrid-custody/get_spec_balance_from_public.cdc
@@ -1,0 +1,37 @@
+import "FungibleToken"
+import "HybridCustody"
+
+/// Returns a dictionary of VaultInfo indexed on the Type of Vault
+///
+pub fun getVaultBalance(_ address: Address, _ balancePath: PublicPath): UFix64 {
+    return getAccount(address).getCapability<&{FungibleToken.Balance}>(balancePath).borrow()?.balance ?? 0.0
+}
+
+/// Queries for FT.Vault balance of all FT.Vaults at given path in the specified account and all of its associated accounts
+///
+pub fun main(address: Address, balancePath: PublicPath): {Address: UFix64} {
+
+    // Get the balance for the given address
+    let balances: {Address: UFix64} = { address: getVaultBalance(address, balancePath) }
+    // Tracking Addresses we've come across to prevent overwriting balances more efficiently than checking return mapping
+    let seen: [Address] = [address]
+    
+    /* Iterate over any associated accounts */ 
+    //
+    if let managerRef = getAuthAccount(address).borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+        
+        for childAccount in managerRef.getChildAddresses() {
+            balances.insert(key: childAccount, getVaultBalance(address, balancePath))
+            seen.append(childAccount)
+        }
+
+        for ownedAccount in managerRef.getOwnedAddresses() {
+            if seen.contains(ownedAccount) == false {
+                balances.insert(key: ownedAccount, getVaultBalance(address, balancePath))
+                seen.append(ownedAccount)
+            }
+        }
+    }
+
+    return balances 
+}

--- a/scripts/test/get_all_vault_bal_from_storage.cdc
+++ b/scripts/test/get_all_vault_bal_from_storage.cdc
@@ -1,0 +1,63 @@
+import "FungibleToken"
+import "MetadataViews"
+import "HybridCustody"
+
+/// Returns a mapping of balances indexed on the Type of resource containing the balance
+///
+pub fun getAllBalancesInStorage(_ address: Address): {String: UFix64} {
+    // Get the account
+    let account: AuthAccount = getAuthAccount(address)
+    // Init for return value
+    let balances: {String: UFix64} = {}
+    // Track seen Types in array
+    let seen: [Type] = []
+    // Assign the type we'll need
+    let balanceType: Type = Type<@{FungibleToken.Balance}>()
+    // Iterate over all stored items & get the path if the type is what we're looking for
+    account.forEachStored(fun (path: StoragePath, type: Type): Bool {
+        if type.isInstance(balanceType) || type.isSubtype(of: balanceType) {
+            // Get a reference to the resource & its balance
+            let vaultRef = account.borrow<&{FungibleToken.Balance}>(from: path)!
+            // Insert a new values if it's the first time we've seen the type
+            if !seen.contains(type) {
+                balances.insert(key: type.identifier, vaultRef.balance)
+            } else {
+                // Otherwise just update the balance of the vault (unlikely we'll see the same type twice in
+                // the same account, but we want to cover the case)
+                balances[type.identifier] = balances[type.identifier]! + vaultRef.balance
+            }
+        }
+        return true
+    })
+    return balances
+}
+
+/// Queries for FT.Vault balance of all FT.Vaults in the specified account and all of its associated accounts
+///
+pub fun main(address: Address): {Address: {String: UFix64}} {
+
+    // Get the balance for the given address
+    let balances: {Address: {String: UFix64}} = { address: getAllBalancesInStorage(address) }
+    // Tracking Addresses we've come across to prevent overwriting balances (more efficient than checking dict entries (?))
+    let seen: [Address] = [address]
+    
+    /* Iterate over any associated accounts */ 
+    //
+    if let managerRef = getAuthAccount(address)
+        .borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) {
+        
+        for childAccount in managerRef.getChildAddresses() {
+            balances.insert(key: childAccount, getAllBalancesInStorage(address))
+            seen.append(childAccount)
+        }
+
+        for ownedAccount in managerRef.getOwnedAddresses() {
+            if seen.contains(ownedAccount) == false {
+                balances.insert(key: ownedAccount, getAllBalancesInStorage(address))
+                seen.append(ownedAccount)
+            }
+        }
+    }
+
+    return balances 
+}

--- a/scripts/test/get_flow_balance.cdc
+++ b/scripts/test/get_flow_balance.cdc
@@ -1,0 +1,3 @@
+pub fun main(address: Address): UFix64 {
+    return getAccount(address).balance
+}

--- a/test/HybridCustody_tests.cdc
+++ b/test/HybridCustody_tests.cdc
@@ -2,7 +2,6 @@ import Test
 
 pub var accounts: {String: Test.Account} = {}
 pub var blockchain = Test.newEmulatorBlockchain()
-pub let flowTokenAccount: Address = 0x0ae53cb6e3f42a79
 pub let fungibleTokenAddress: Address = 0xee82856bf20e2aa6
 
 pub let app = "app"


### PR DESCRIPTION
Related: #26

Note about test coverage - I was having difficulty getting `scriptExecutor()` to return the `{Address: {Type: UFix64}}` from `get_all_vault_bal_from_storage`. I kept running into the following error when executing the script despite successful manual testing:

```
- FAIL: testGetAllFTBalance
		Execution failed:
			error: assertion failed: Failed to execute the script because -:  cannot import dictionary: keys does not belong to the same type
			   --> 7465737400000000000000000000000000000000000000000000000000000000:518:4
```

This occurred with and without casting the return value, which makes me wonder if it's something funky going on with the test framework.

Regardless, wanted to get this PR in before EOD.