### PR TITLE
Add blockchain-native onboarding transaction

### DIFF
--- a/flow.json
+++ b/flow.json
@@ -40,8 +40,8 @@
 			"source": "./modules/flow-nft/contracts/NonFungibleToken.cdc",
 			"aliases": {
 				"emulator": "0xf8d6e0586b0a20c7",
-				"testnet": "0x7e60df042a9c0868",
-				"mainnet": "0x1654653399040a61"
+				"testnet": "0x631e88ae7f1d7c20",
+				"mainnet": "0x1d7e57aa55817448"
 			}
 		},
 		"MetadataViews": {
@@ -69,11 +69,10 @@
 			}
 		},
 		"FlowToken": {
-			"source": "",
 			"aliases": {
 				"emulator": "0x0ae53cb6e3f42a79",
-				"testnet": "0x9a0766d93b6608b7",
-				"mainnet": "0xf233dcee88fe0abe"
+				"testnet": "0x7e60df042a9c0868",
+				"mainnet": "0x1654653399040a61"
 			}
 		},
 		"AddressUtils": {

--- a/flow.json
+++ b/flow.json
@@ -40,8 +40,8 @@
 			"source": "./modules/flow-nft/contracts/NonFungibleToken.cdc",
 			"aliases": {
 				"emulator": "0xf8d6e0586b0a20c7",
-				"testnet": "0x631e88ae7f1d7c20",
-				"mainnet": "0x1d7e57aa55817448"
+				"testnet": "0x7e60df042a9c0868",
+				"mainnet": "0x1654653399040a61"
 			}
 		},
 		"MetadataViews": {
@@ -64,6 +64,14 @@
 			"source": "./modules/flow-nft/contracts/utility/FungibleToken.cdc",
 			"aliases": {
 				"emulator": "0xee82856bf20e2aa6",
+				"testnet": "0x9a0766d93b6608b7",
+				"mainnet": "0xf233dcee88fe0abe"
+			}
+		},
+		"FlowToken": {
+			"source": "",
+			"aliases": {
+				"emulator": "0x0ae53cb6e3f42a79",
 				"testnet": "0x9a0766d93b6608b7",
 				"mainnet": "0xf233dcee88fe0abe"
 			}

--- a/transactions/hybrid-custody/onboarding/blockchain-native.cdc
+++ b/transactions/hybrid-custody/onboarding/blockchain-native.cdc
@@ -1,0 +1,133 @@
+#allowAccountLinking
+
+import "FungibleToken"
+import "FlowToken"
+import "MetadataViews"
+
+import "HybridCustody"
+import "CapabilityFactory"
+import "CapabilityFilter"
+import "CapabilityProxy"
+
+transaction(
+    pubKey: String,
+    initialFundingAmt: UFix64,
+    factoryAddress: Address,
+    filterAddress: Address
+) {
+
+    prepare(parent: AuthAccount, app: AuthAccount) {
+        /* --- Account Creation --- */
+		//
+		// Create the child account, funding via the signing app account
+		let newAccount = AuthAccount(payer: app)
+		// Create a public key for the proxy account from string value in the provided arg
+		// **NOTE:** You may want to specify a different signature algo for your use case
+		let key = PublicKey(
+			publicKey: pubKey.decodeHex(),
+			signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+		)
+		// Add the key to the new account
+		// **NOTE:** You may want to specify a different hash algo & weight best for your use case
+		newAccount.keys.add(
+			publicKey: key,
+			hashAlgorithm: HashAlgorithm.SHA3_256,
+			weight: 1000.0
+		)
+
+		/* --- (Optional) Additional Account Funding --- */
+		//
+		// Fund the new account if specified
+		if initialFundingAmt > 0.0 {
+			// Get a vault to fund the new account
+			let fundingProvider = app.borrow<&FlowToken.Vault{FungibleToken.Provider}>(
+					from: /storage/flowTokenVault
+				)!
+			// Fund the new account with the initialFundingAmount specified
+			newAccount.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+                .borrow()!
+			    .deposit(
+                    from: <-fundingProvider.withdraw(
+                        amount: initialFundingAmt
+                    )
+                )
+		}
+
+		/* Continue with use case specific setup */
+		//
+		// At this point, the newAccount can further be configured as suitable for
+		// use in your dapp (e.g. Setup a Collection, Mint NFT, Configure Vault, etc.)
+		// ...
+
+        /* --- Link the AuthAccount Capability --- */
+        //
+        var acctCap = newAccount.linkAccount(HybridCustody.LinkedAccountPrivatePath)
+            ?? panic("problem linking account Capability for new account")
+
+        // Create a ChildAccount & link Capabilities
+        let ChildAccount <- HybridCustody.createChildAccount(acct: acctCap)
+        newAccount.save(<-ChildAccount, to: HybridCustody.ChildStoragePath)
+        newAccount
+            .link<&HybridCustody.ChildAccount{HybridCustody.BorrowableAccount, HybridCustody.ChildAccountPublic, HybridCustody.ChildAccountPrivate}>(
+                HybridCustody.ChildPrivatePath,
+                target: HybridCustody.ChildStoragePath
+            )
+        newAccount
+            .link<&HybridCustody.ChildAccount{HybridCustody.ChildAccountPublic}>(
+                HybridCustody.ChildPublicPath, 
+                target: HybridCustody.ChildStoragePath
+            )
+
+        // Get a reference to the ChildAccount resource
+        let child = newAccount.borrow<&HybridCustody.ChildAccount>(from: HybridCustody.ChildStoragePath)!
+
+        // Get the CapabilityFactory.Manager Capability
+        let factory = getAccount(factoryAddress)
+            .getCapability<&CapabilityFactory.Manager{CapabilityFactory.Getter}>(
+                CapabilityFactory.PublicPath
+            )
+        assert(factory.check(), message: "factory address is not configured properly")
+
+        // Get the CapabilityFilter.Filter Capability
+        let filter = getAccount(filterAddress).getCapability<&{CapabilityFilter.Filter}>(CapabilityFilter.PublicPath)
+        assert(filter.check(), message: "capability filter is not configured properly")
+
+        // Configure access for the delegatee parent account
+        child.publishToParent(parentAddress: parent.address, factory: factory, filter: filter)
+
+        /* --- Add delegation to parent account --- */
+        //
+        // Configure HybridCustody.Manager if needed
+        if parent.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath) == nil {
+            let m <- HybridCustody.createManager(filter: filter)
+            parent.save(<- m, to: HybridCustody.ManagerStoragePath)
+        }
+
+        // Link Capabilities
+        parent.unlink(HybridCustody.ManagerPublicPath)
+        parent.unlink(HybridCustody.ManagerPrivatePath)
+        parent.link<&HybridCustody.Manager{HybridCustody.ManagerPrivate, HybridCustody.ManagerPublic}>(
+            HybridCustody.ManagerPrivatePath,
+            target: HybridCustody.ManagerStoragePath
+        )
+        parent.link<&HybridCustody.Manager{HybridCustody.ManagerPublic}>(
+            HybridCustody.ManagerPublicPath,
+            target: HybridCustody.ManagerStoragePath
+        )
+        
+        // Claim the ProxyAccount Capability
+        let inboxName = HybridCustody.getProxyAccountIdentifier(parent.address)
+        let cap = parent
+            .inbox
+            .claim<&HybridCustody.ProxyAccount{HybridCustody.AccountPrivate, HybridCustody.AccountPublic, MetadataViews.Resolver}>(
+                inboxName,
+                provider: newAccount.address
+            ) ?? panic("proxy account cap not found")
+        
+        // Get a reference to the Manager and add the account
+        let managerRef = parent.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)
+            ?? panic("manager no found")
+        managerRef.addAccount(cap)
+    }
+}
+ 

--- a/transactions/hybrid-custody/onboarding/blockchain-native.cdc
+++ b/transactions/hybrid-custody/onboarding/blockchain-native.cdc
@@ -18,46 +18,46 @@ transaction(
 
     prepare(parent: AuthAccount, app: AuthAccount) {
         /* --- Account Creation --- */
-		//
-		// Create the child account, funding via the signing app account
-		let newAccount = AuthAccount(payer: app)
-		// Create a public key for the proxy account from string value in the provided arg
-		// **NOTE:** You may want to specify a different signature algo for your use case
-		let key = PublicKey(
-			publicKey: pubKey.decodeHex(),
-			signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
-		)
-		// Add the key to the new account
-		// **NOTE:** You may want to specify a different hash algo & weight best for your use case
-		newAccount.keys.add(
-			publicKey: key,
-			hashAlgorithm: HashAlgorithm.SHA3_256,
-			weight: 1000.0
-		)
+        //
+        // Create the child account, funding via the signing app account
+        let newAccount = AuthAccount(payer: app)
+        // Create a public key for the proxy account from string value in the provided arg
+        // **NOTE:** You may want to specify a different signature algo for your use case
+        let key = PublicKey(
+            publicKey: pubKey.decodeHex(),
+            signatureAlgorithm: SignatureAlgorithm.ECDSA_P256
+        )
+        // Add the key to the new account
+        // **NOTE:** You may want to specify a different hash algo & weight best for your use case
+        newAccount.keys.add(
+            publicKey: key,
+            hashAlgorithm: HashAlgorithm.SHA3_256,
+            weight: 1000.0
+        )
 
-		/* --- (Optional) Additional Account Funding --- */
-		//
-		// Fund the new account if specified
-		if initialFundingAmt > 0.0 {
-			// Get a vault to fund the new account
-			let fundingProvider = app.borrow<&FlowToken.Vault{FungibleToken.Provider}>(
-					from: /storage/flowTokenVault
-				)!
-			// Fund the new account with the initialFundingAmount specified
-			newAccount.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)
+        /* --- (Optional) Additional Account Funding --- */
+        //
+        // Fund the new account if specified
+        if initialFundingAmt > 0.0 {
+            // Get a vault to fund the new account
+            let fundingProvider = app.borrow<&FlowToken.Vault{FungibleToken.Provider}>(
+                    from: /storage/flowTokenVault
+                )!
+            // Fund the new account with the initialFundingAmount specified
+            newAccount.getCapability<&FlowToken.Vault{FungibleToken.Receiver}>(/public/flowTokenReceiver)
                 .borrow()!
-			    .deposit(
+                .deposit(
                     from: <-fundingProvider.withdraw(
                         amount: initialFundingAmt
                     )
                 )
-		}
+        }
 
-		/* Continue with use case specific setup */
-		//
-		// At this point, the newAccount can further be configured as suitable for
-		// use in your dapp (e.g. Setup a Collection, Mint NFT, Configure Vault, etc.)
-		// ...
+        /* Continue with use case specific setup */
+        //
+        // At this point, the newAccount can further be configured as suitable for
+        // use in your dapp (e.g. Setup a Collection, Mint NFT, Configure Vault, etc.)
+        // ...
 
         /* --- Link the AuthAccount Capability --- */
         //


### PR DESCRIPTION
Related: #50

Adds a multisig blockchain-native onboarding transaction that:

1. Creates a new dev-funded account
2. Configures a `ChildAccount` in the new account
3. Configures a `HybridCustody.Manager` in the signing parent account (if needed)
4. Adds a `ProxyAccount` Capability on the new account to the parent's `Manager`

The ultimate result is a new account that is linked to the signing parent in a single mulitisig transaction. Pre-requisites for this transaction include configuring Filter Manager & Factory resources & Capabilities, the addresses for which are provided as transaction args along with the public key hex to add on the new account and amount of $FLOW to seed to the new account.