### PR TITLE
rename Account interface to OwnedAccount

### DIFF
--- a/transactions/hybrid-custody/accept_ownership.cdc
+++ b/transactions/hybrid-custody/accept_ownership.cdc
@@ -21,7 +21,7 @@ transaction(childAddress: Address, filterAddress: Address?, filterPath: PublicPa
         }
 
         let inboxName = HybridCustody.getOwnerIdentifier(acct.address) 
-        let cap = acct.inbox.claim<&AnyResource{HybridCustody.Account, HybridCustody.ChildAccountPublic, HybridCustody.ChildAccountPrivate, MetadataViews.Resolver}>(inboxName, provider: childAddress)
+        let cap = acct.inbox.claim<&AnyResource{HybridCustody.OwnedAccount, HybridCustody.ChildAccountPublic, HybridCustody.ChildAccountPrivate, MetadataViews.Resolver}>(inboxName, provider: childAddress)
             ?? panic("proxy account cap not found")
 
         let manager = acct.borrow<&HybridCustody.Manager>(from: HybridCustody.ManagerStoragePath)


### PR DESCRIPTION
The Account type flip found [here](https://github.com/onflow/flips/pull/92) is set to define a new type which will cause a conflict in our own type definitions. AuthAccount is going to be split into a set of interfaces and a concrete called `Account` which we also define. If the flip were to be implemented, that type would brick our own contract due to `Account` being a reserved type/keyword.

Since we aren't in mainnet yet, we can rename the type here and avoid the conflict entirely.

